### PR TITLE
feat : 404 페이지 핸들링

### DIFF
--- a/nextjs-course/app/clients/[id]/page.js
+++ b/nextjs-course/app/clients/[id]/page.js
@@ -12,7 +12,7 @@ export default function ClientDetailPage({ params }){
 
     return (
         <div>
-            <h1>ClientDetailId : {queryId} </h1>
+            <h1>ClientDetailId : {queryId ? queryId : id} </h1>
         </div>
     )
 }

--- a/nextjs-course/app/clients/page.js
+++ b/nextjs-course/app/clients/page.js
@@ -1,25 +1,49 @@
+'use client'
+
 import Link from 'next/link';
+import { useRouter,usePathname, useSearchParams } from 'next/navigation';
 
 function ClientPage() {
+
+    const router = useRouter();
+
 
     const clients = [
       { id : 'max', name: 'Maximilian'},
       { id : 'manu', name: 'Manuel'},
     ];
 
+    function loadProjectHandler() {
+        // load data...
+
+        // Next.js 13 버전에서는 객체 형식으로 페이지를 이동하는 것이 더 이상 지원되지 않음
+        // router.push({
+        //     pathname: '/clients/[id]',
+        //     query: { id: 'max'}
+        // });
+
+        router.push('/clients/max')
+    }
+
     return (
         <div>
             <h1>The Clients Page</h1>
+            <h2>페이지 네비게이션</h2>
             <ul>
                 {clients.map(client => <li key={client.id}>
                     {/* <Link href={`/clients/${client.id}`}>{client.name}</Link> */}
-                    {/* 현재 아래 문법 버전 13에서 지원 안함  */}
+                    {/* 현재 아래 객체 형식 문법 버전 13에서 지원 안함  */}
                     {/* <Link href={{
                         pathname: '/clients/[id]',
                         query: { id: client.id },
                     }}>{client.name}</Link> */}
                     <Link href={`/clients/[id]?id=${client.id}`}>{client.name}</Link>
                 </li>)}
+            </ul>
+            <ul>
+                <li>
+                    <button onClick={loadProjectHandler}>Load Projecft A</button>
+                </li>
             </ul>
         </div>
     );

--- a/nextjs-course/app/not-found.js
+++ b/nextjs-course/app/not-found.js
@@ -1,0 +1,9 @@
+function NotFoundPage(){
+    return ( 
+        <div>
+            <h1>Page not found!</h1>
+        </div>
+    );
+}
+
+export default NotFoundPage;


### PR DESCRIPTION
예전 버전 NextJS에서는 pages 폴더 안에서 404.js 컴포넌트를 통해서 에러페이지 핸들링 했었는데 NextJS 13 버전으로 넘어오면서 app 폴더 안 not-found.js 컴포넌트를 통해서 에러페이지를 핸들링해줍니다.